### PR TITLE
fix: Remove token validation in unlinking process

### DIFF
--- a/src/middlewares/token.middleware.js
+++ b/src/middlewares/token.middleware.js
@@ -76,8 +76,28 @@ function verifyTokenWithRole(role) { // wrapper for custom args
   } // end of standard middleware
 } // end of wrapper
 
+// Decode token information and cross check role in token is role in arg
+function decodeToken(role) { // wrapper for custom args
+  return (req, res, next) => {
+    const decodedToken = jwt.decode(req.token);
+
+    if (decodedToken.role !== role) {
+      res.status(403).json({
+        status: responseCodes.VERIFICATION_INVALID_ROLE,
+        message: "Role invalid"
+      });
+      return;
+    }
+
+    req.username = decodedToken.username;
+    req.role = decodedToken.role;
+    next();
+  } // end of standard middleware
+} // end of wrapper
+
 module.exports = {
   getTokenFromCookie,
   getTokenFromBearer,
-  verifyTokenWithRole
+  verifyTokenWithRole,
+  decodeToken
 }

--- a/src/middlewares/token.middleware.js
+++ b/src/middlewares/token.middleware.js
@@ -37,9 +37,12 @@ function getTokenFromBearer(req, res, next) {
 }
 
 // Verify token is valid, and role in token is role in arg
-function verifyTokenWithRole(role) { // wrapper for custom args
+function verifyTokenWithRole(role, ignoreExpiration = false) { // wrapper for custom args
   return (req, res, next) => {
-    jwt.verify(req.token, process.env.ACCESS_TOKEN_PRIVATE_KEY, (err, decodedToken) => {
+    jwt.verify(req.token, 
+      process.env.ACCESS_TOKEN_PRIVATE_KEY, 
+      {ignoreExpiration: ignoreExpiration}, 
+      (err, decodedToken) => {
 
       if (err) {
         if (err.name == 'JsonWebTokenError'){
@@ -76,28 +79,8 @@ function verifyTokenWithRole(role) { // wrapper for custom args
   } // end of standard middleware
 } // end of wrapper
 
-// Decode token information and cross check role in token is role in arg
-function decodeToken(role) { // wrapper for custom args
-  return (req, res, next) => {
-    const decodedToken = jwt.decode(req.token);
-
-    if (decodedToken.role !== role) {
-      res.status(403).json({
-        status: responseCodes.VERIFICATION_INVALID_ROLE,
-        message: "Role invalid"
-      });
-      return;
-    }
-
-    req.username = decodedToken.username;
-    req.role = decodedToken.role;
-    next();
-  } // end of standard middleware
-} // end of wrapper
-
 module.exports = {
   getTokenFromCookie,
   getTokenFromBearer,
-  verifyTokenWithRole,
-  decodeToken
+  verifyTokenWithRole
 }

--- a/src/routes/devices.route.js
+++ b/src/routes/devices.route.js
@@ -3,7 +3,8 @@ const DeviceController = require('../controllers/device.controller');
 const {
   getTokenFromCookie,
   getTokenFromBearer,
-  verifyTokenWithRole
+  verifyTokenWithRole,
+  decodeToken
 } = require('../middlewares/token.middleware')
 
 const router = express.Router(); 
@@ -234,7 +235,7 @@ router.route('/link').post(
   */
 router.route('/unlink').post( // Sensor devices that will request for unlinking with a citizen acct requires bearer token
 getTokenFromBearer,
-verifyTokenWithRole('sensor'),
+decodeToken('sensor'),
 DeviceController.unlinkDevice
 )
 

--- a/src/routes/devices.route.js
+++ b/src/routes/devices.route.js
@@ -3,8 +3,7 @@ const DeviceController = require('../controllers/device.controller');
 const {
   getTokenFromCookie,
   getTokenFromBearer,
-  verifyTokenWithRole,
-  decodeToken
+  verifyTokenWithRole
 } = require('../middlewares/token.middleware')
 
 const router = express.Router(); 
@@ -235,7 +234,7 @@ router.route('/link').post(
   */
 router.route('/unlink').post( // Sensor devices that will request for unlinking with a citizen acct requires bearer token
 getTokenFromBearer,
-decodeToken('sensor'),
+verifyTokenWithRole('sensor', ignoreExpiration = true),
 DeviceController.unlinkDevice
 )
 


### PR DESCRIPTION
# Detailed Description

### Summary
<!--- Please link the related issue/task --> 
<!--- > This PR fixes: [SEISMO #### - Title](issue-link) -->

<!--- Please include a detailed summary of the changes --> 
 In this PR, I edited the middleware function (_verifyTokenWithRole_) used in unlinking process (and in other endpoints as well). _ignoreExpiry_ option is added to the function which ignores the validity check of the supplied token and proceeds with properly decoding of token.
Note:
- jwt.verify(token, secretOrPublicKey, [options, callback]) can only properly decode/parse the token if the token supplied is valid.
 
### Motivation & Context
<!--- Why is this change required? What problem does it solve? -->
Devices with expired token can't perform unlinking process properly since their token is invalid. So instead of performing validity check to their token during unlinking process, _ignoreExpiry_ option is added to the middleware function to skip token validity check if the option is set to _true_. With this change, unlinking even with expired token can now be performed. Making sure that other endpoints using the same middleware function still functions properly.

<!--- If it fixes an open issue, please link to the issue here. -->
### Dependencies
<!--- List any dependencies that are required for this change. -->

### Type of change
<!--- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!--- If breaking change, detail which existing functionality/s should or is expected to change -->


# How Has This Been Tested?
<!--- Remove this section if not applicable -->

<!--- Please describe the tests that you ran to verify your changes. -->
<!--- Provide instructions so we can reproduce. -->
<!--- Please also list any relevant details for your test configuration -->

1. Using an expired token to unlink a device, using the expired token saved in Postman.
Endpoint: http://172.22.0.3:5000/device/unlink
![image](https://github.com/UPRI-earthquake/earthquake-hub-backend/assets/80037186/b8c8c119-f52c-41cd-8f3b-6d8ad4dcc0a9)
The token used is already expired ~4months ago (Sept 2023).
![image](https://github.com/UPRI-earthquake/earthquake-hub-backend/assets/80037186/40107cd3-415d-468b-93c0-aaaa738f8127)
Even with expired token, the unlinking process still proceeds.
2. Using a valid token to unlink a device still proceeds properly.
![image](https://github.com/UPRI-earthquake/earthquake-hub-backend/assets/80037186/4b2494df-75c9-4287-ba91-59ed83368f3e)
3. Checking if other endpoints that uses the same middleware function _verifyTokenWithRole_ is not affected by the change.
- [x] http://172.22.0.3:5000/accounts/profile
![image](https://github.com/UPRI-earthquake/earthquake-hub-backend/assets/80037186/2356c18d-60d7-46af-8a72-21940d67d4ee)
- [x] http://172.22.0.3:5000/device/my-devices
![image](https://github.com/UPRI-earthquake/earthquake-hub-backend/assets/80037186/1e6a0096-5188-4c15-935d-82d71da098d9)
- [x] http://172.22.0.3:5000/accounts/verify-sensor-token
![image](https://github.com/UPRI-earthquake/earthquake-hub-backend/assets/80037186/a6a46ad1-078c-494e-be92-913614e1a030)
 



# Checklist:
<!--- Double check the following and leave uncheck those that you haven't done or are not applicable. -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
