### PR TITLE
feat: [SEISMO-XXXX] Significant EQs Page

### DIFF
--- a/src/controllers/significantEQs.controller.js
+++ b/src/controllers/significantEQs.controller.js
@@ -39,3 +39,43 @@ exports.getAllSignificantEQs = async (req, res, next) => {
         next(error)
     }
 }
+
+exports.getEarthquakeInfo = async (req, res, next) => {
+    // Validation
+    const { id } = req.body; // Check if the `id` query parameter is present
+
+    try {
+        // Perform Task
+        returnObj = await SignificantEQsService.getEarthquakeInfo(id);
+
+        //Respond based on returned value
+        let message = "";
+
+        switch (returnObj.str){
+            case "noEarthquakeInfoFound":
+                message = "No Earthquake Information found in DB!";
+                res.status(400).json({
+                    status: responseCodes.GENERIC_ERROR,
+                    message: message
+                });
+                break;
+            case "success":
+                message = 'Earthquake Information found';
+                res.status(200).json({
+                    status: responseCodes.GENERIC_SUCCESS,
+                    message: message,
+                    payload: returnObj.earthquakeInfo
+                });
+                break;
+            default:
+                throw Error(`Unhandled return value ${returnObj} from service.getEarthquakeInfo()`);
+        }
+
+        res.message = message; // used by next middleware
+
+        return;
+    } catch (error) {
+        console.log(`Getting all significant earthquakes unsuccessful: \n ${error}`);
+        next(error)
+    }
+}

--- a/src/controllers/significantEQs.controller.js
+++ b/src/controllers/significantEQs.controller.js
@@ -1,0 +1,41 @@
+const SignificantEQsService = require('../services/significantEQs.service')
+const {responseCodes} = require('./responseCodes')
+
+exports.getAllSignificantEQs = async (req, res, next) => {
+    // Validation
+
+    try {
+        // Perform Task
+        returnObj = await SignificantEQsService.getAllSignificantEQs();
+
+        //Respond based on returned value
+        let message = "";
+
+        switch (returnObj.str){
+            case "noSignificantEQsFound":
+                message = "No Significant Earthquakes found in DB!";
+                res.status(400).json({
+                    status: responseCodes.GENERIC_ERROR,
+                    message: message
+                });
+                break;
+            case "success":
+                message = 'All Significant Earthquakes found';
+                res.status(200).json({
+                    status: responseCodes.GENERIC_SUCCESS,
+                    message: message,
+                    payload: returnObj.significantEQs
+                });
+                break;
+            default:
+                throw Error(`Unhandled return value ${returnObj} from service.getAllSignificantEQs()`);
+        }
+
+        res.message = message; // used by next middleware
+
+        return;
+    } catch (error) {
+        console.log(`Getting all significant earthquakes unsuccessful: \n ${error}`);
+        next(error)
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -108,6 +108,7 @@ app.use('/device', require('./routes/devices.route'))
 app.use('/messaging', require('./routes/messaging.route'))
 app.use('/notifications', require('./routes/notifications.route'))
 app.use('/eq-events', require('./routes/EQevents.route'))
+app.use('/significant-eqs', require('./routes/significantEQs.route'))
 
 // TODO: Test for multiple origin 
 // app.use((req, res, next) => {

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -2,4 +2,5 @@
 require('./account.model.js');
 require('./device.model.js');
 require('./events.model.js');
+require('./significantEQ.model.js')
 

--- a/src/models/significantEQ.model.js
+++ b/src/models/significantEQ.model.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+const SignificantEQsSchema = new mongoose.Schema({
+    title: String,
+    magnitude: Number,
+    longitude: Number,
+    latitude: Number,
+    depth: Number,
+    location: String,
+    eventTime: Date,
+    instrumentRecordings: Array,
+    eventSummary: String,
+    references: Array
+});
+
+module.exports = mongoose.model('significant-eq', SignificantEQsSchema);

--- a/src/routes/significantEQs.route.js
+++ b/src/routes/significantEQs.route.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+
+const SignificantEQsController = require('../controllers/significantEQs.controller')
+
+router.route('/all').get(
+    SignificantEQsController.getAllSignificantEQs
+);
+
+
+module.exports = router;

--- a/src/routes/significantEQs.route.js
+++ b/src/routes/significantEQs.route.js
@@ -7,5 +7,9 @@ router.route('/all').get(
     SignificantEQsController.getAllSignificantEQs
 );
 
+router.route('/').post(
+    SignificantEQsController.getEarthquakeInfo
+);
+
 
 module.exports = router;

--- a/src/services/significantEQs.service.js
+++ b/src/services/significantEQs.service.js
@@ -1,7 +1,6 @@
 const SignificantEQs = require('../models/significantEQ.model');
 
 exports.getAllSignificantEQs = async () => {
-    console.log(SignificantEQs);
     const allSignificantEQs = await SignificantEQs.find({});
     console.log('EQs:' + allSignificantEQs)
     console.log(allSignificantEQs.length)
@@ -13,5 +12,19 @@ exports.getAllSignificantEQs = async () => {
     return {
         str: 'success',
         significantEQs: allSignificantEQs
+    };
+}
+
+exports.getEarthquakeInfo = async (id) => {
+    const earthquakeInfo = await SignificantEQs.findById(id);
+    console.log('EQ Info:' + earthquakeInfo)
+
+    if (!earthquakeInfo) {
+        return {str: 'noSignificantEQsFound'};
+    }
+
+    return {
+        str: 'success',
+        earthquakeInfo: earthquakeInfo
     };
 }

--- a/src/services/significantEQs.service.js
+++ b/src/services/significantEQs.service.js
@@ -1,0 +1,17 @@
+const SignificantEQs = require('../models/significantEQ.model');
+
+exports.getAllSignificantEQs = async () => {
+    console.log(SignificantEQs);
+    const allSignificantEQs = await SignificantEQs.find({});
+    console.log('EQs:' + allSignificantEQs)
+    console.log(allSignificantEQs.length)
+
+    if (allSignificantEQs.length === 0) {
+        return {str: 'noSignificantEQsFound'};
+    }
+
+    return {
+        str: 'success',
+        significantEQs: allSignificantEQs
+    };
+}

--- a/src/significantEQs.json
+++ b/src/significantEQs.json
@@ -1,0 +1,122 @@
+[
+  {
+    "title": "M7.4 Earthquake 029 km N 74° E of Hinatuan (Surigao Del Sur)",
+    "magnitude": 7.4,
+    "location": "029 km N 74° E of Hinatuan (Surigao Del Sur)",
+    "latitude": 8.44,
+    "longitude": 126.59,
+    "depth": 26,
+    "eventTime": "12-02-2023T22:37:05.000+00:00",
+    "instrumentRecordings": "[R1382,R8095,RBD68]",
+    "eventSummary": "A magnitude 7.4 earthquake struck Surigao del Sur on December 2, resulting in three deaths, 48 injuries, 9,765 affected families and nearly 3,000 aftershocks ranging from magnitude 1.4 to 6.6. Significant damage includes destroyed homes, a fire in a Butuan City hospital and disrupted infrastructure estimated to be valued at around P45 million.",
+    "references": "[https://earthquake.phivolcs.dost.gov.ph/2023_Earthquake_Information/December/2023_1202_1437_B3F.html, https://newsinfo.inquirer.net/1869567/live-updates-magnitude-7-4-surigao-del-sur-earthquake, https://www.rappler.com/philippines/mindanao/surigao-del-sur-earthquake-december-2-2023/, https://newsinfo.inquirer.net/1869567/live-updates-magnitude-7-4-surigao-del-sur-earthquake]"
+  },
+  {
+    "title": "M7 Earthquake 003 km N 50° W of Tayum (Abra)",
+    "magnitude": 7,
+    "location": "003 km N 50° W of Tayum (Abra)",
+    "latitude": 17.63,
+    "longitude": 120.63,
+    "depth": 15,
+    "eventTime": "07-27-2022T08:43:24.000+00:00",
+    "instrumentRecordings": "[R1077,R1382,R1EFC,R29BF,R3B2D,R8095,RF8C0]",
+    "eventSummary": "-  4795 recorded aftershocks with strength ranging from 1.4-5.1\n-  156,020 affected Families\n-  36,313 damaged Houses\n- 1,678 damaged Infrastructure with estimated cost amounting to ₱ 2,617,926,891.65\n- with intensity range of I-VII",
+    "references": "[https://earthquake.phivolcs.dost.gov.ph/2022_Earthquake_Information/July/2022_0727_0043_B3F.html]"
+  },
+  {
+    "title": "M7 Earthquake 335 km S 32° E of Balut Island (Municipality Of Sarangani) (Davao Occidental)",
+    "magnitude": 7,
+    "location": "335 km S 32° E of Balut Island (Municipality Of Sarangani) (Davao Occidental)",
+    "latitude": 2.86,
+    "longitude": 127.04,
+    "depth": 15,
+    "eventTime": "01-18-2023T14:06:10.000+00:00",
+    "instrumentRecordings": "[R1EFC,R29BF,R3B2D,RBD68,RF8C0]",
+    "eventSummary": "Paragraphical:\nA magnitude 7 earthquake struck off Davao Occidental on January 18, 2023, at a depth of 67 kilometers, with no tsunami threat reported by Phivolcs. The earthquake was initially reported as magnitude 7.3 but was later downgraded to 7 with intensities I-II.\n\nBulleted:\n\n- No damages reported\n- with intensities I-II",
+    "references": "[https://earthquake.phivolcs.dost.gov.ph/2023_Earthquake_Information/January/2023_0118_0606_B3F.html]"
+  },
+  {
+    "title": "M6.8 Earthquake 028 km S 68° W of Sarangani Island (Municipality Of Sarangani) (Davao Occidental)",
+    "magnitude": 6.8,
+    "location": "028 km S 68° W of Sarangani Island (Municipality Of Sarangani) (Davao Occidental)",
+    "latitude": 5.38,
+    "longitude": 125.24,
+    "depth": 63,
+    "eventTime": "11-17-2023T16:14:08.000+00:00",
+    "instrumentRecordings": "[R1382,R8095,REBEA]",
+    "eventSummary": "- 150 recorded aftershocks with magnitude ranging from 1.4-4.9\n-  20,575 affected families\n- 11 deaths and 37 injured\n-  6,585 damaged Houses with estimated cost of damaged houses\namounting to ₱ 202,663,671.64\n- 535 damaged Infrastructure with estimated cost of damaged Infrastructure\namounting to ₱ 1,422,471,456.87\n- with intensity range of I-VII",
+    "references": "[https://earthquake.phivolcs.dost.gov.ph/2023_Earthquake_Information/November/2023_1117_0814_B4F.html, https://monitoring-dashboard.ndrrmc.gov.ph/page/situation/magnitude-68-earthquake-in-sarangani-davao-occidental]"
+  },
+  {
+    "title": "M6.8 Earthquake 067 km N 87° E of Cagwait (Surigao Del Sur)",
+    "magnitude": 6.8,
+    "location": "067 km N 87° E of Cagwait (Surigao Del Sur)",
+    "latitude": 8.96,
+    "longitude": 126.91,
+    "depth": 1,
+    "eventTime": "12-04-2023T03:49:33.000+00:00",
+    "instrumentRecordings": "[R1382,R1EFC,R8095]",
+    "eventSummary": "A magnitude 6.8 earthquake struck 63 kilometers off east-southeast of Cagwait in Surigao del Sur on December 4, 2023, following a magnitude 7.4 tremor just a day earlier. The latest quake, with a shallow depth of one kilometer, caused strong ground movement but is unlikely to cause significant damage, though aftershocks are expected.\n\n- with intensity range from I-V",
+    "references": "[https://earthquake.phivolcs.dost.gov.ph/2023_Earthquake_Information/December/2023_1203_1949_B2F.html, https://news.abs-cbn.com/news/12/04/23/magnitude-68-quake-rocks-cagwait-surigao-del-sur, https://newsinfo.inquirer.net/1869924/latest-in-a-series-magnitude-6-7-quake-strikes-again-off-surigao-del-sur]"
+  },
+  {
+    "title": "M6.7 Earthquake 294 km N 06° W of Itbayat (Batanes)",
+    "magnitude": 6.7,
+    "location": "294 km N 06° W of Itbayat (Batanes)",
+    "latitude": 23.43,
+    "longitude": 121.57,
+    "depth": 15,
+    "eventTime": "03-23-2022T01:41:00.000+00:00",
+    "instrumentRecordings": "[R0CE4,R1077,R1382,R1EFC,R29BF,R3B2D,R6BC0,RBD68,REBEA]",
+    "eventSummary": "- No reports available",
+    "references": "[https://earthquake.phivolcs.dost.gov.ph/2022_Earthquake_Information/March/2022_0322_1741_B1F.pdf]"
+  },
+  {
+    "title": "M6.6 Earthquake 069 km N 79° E of Hinatuan (Surigao Del Sur)",
+    "magnitude": 6.6,
+    "location": "069 km N 79° E of Hinatuan (Surigao Del Sur)",
+    "latitude": 8.49,
+    "longitude": 126.95,
+    "depth": 1,
+    "eventTime": "12-03-2023T18:35:50.000+00:00",
+    "instrumentRecordings": "[R1382,R8095,RBD68]",
+    "eventSummary": "- A magnitude 6.6 aftershock struck Hinatuan, Surigao del Sur on December 3, 2023, a day after a magnitude 7.4 earthquake hit the area, prompting tsunami alerts and significant aftershocks.\n\n- with intensities I-V",
+    "references": "[https://earthquake.phivolcs.dost.gov.ph/2023_Earthquake_Information/December/2023_1203_1035_B2F.html, https://www.philstar.com/nation/2023/12/03/2316205/magnitude-66-aftershock-hits-surigao-del-sur]"
+  },
+  {
+    "title": "M6.4 Earthquake 111 km N 79° W of Lubang (Occidental Mindoro)",
+    "magnitude": 6.4,
+    "location": "111 km N 79° W of Lubang (Occidental Mindoro)",
+    "latitude": 14.05,
+    "longitude": 119.11,
+    "depth": 33,
+    "eventTime": "03-14-2022T05:05:48.000+00:00",
+    "instrumentRecordings": "[R0CE4,R1077,R1EFC,R29BF,R3B2D,R6BC0,REBEA,RF8C0]",
+    "eventSummary": "Following a 6.4-magnitude earthquake in Lubang, Occidental Mindoro on March 14, Phivolcs recorded 187 aftershocks, with 54 located near the epicenter. The earthquake, which occurred at a depth of 28 km, was felt strongly in Lubang and weakly in several surrounding areas with intensities I-IV",
+    "references": "[https://earthquake.phivolcs.dost.gov.ph/2022_Earthquake_Information/March/2022_0313_2105_B4F.html, https://www.pna.gov.ph/articles/1169672, https://newsinfo.inquirer.net/1567882/magnitude-6-4-quake-strikes-occidental-mindoro, https://mb.com.ph/2022/3/14/6-4-magnitude-quake-in-occidental-mindoro-triggers-over-180-aftershocks-phivolcs]"
+  },
+  {
+    "title": "M6.4 Earthquake 005 km N 18° E of Lagayan (Abra)",
+    "magnitude": 6.4,
+    "location": "005 km N 18° E of Lagayan (Abra)",
+    "latitude": 17.77,
+    "longitude": 120.72,
+    "depth": 16,
+    "eventTime": "10-25-2022T22:59:02.000+00:00",
+    "instrumentRecordings": "[R1382,R1EFC,R29BF,R3B2D,RF8C0]",
+    "eventSummary": "-  35,798 affected families\n- 139 injured and 0 casualties\n- 14,441 damaged houses\n- 256 damaged Infrastructure with estimated Cost of Damaged Infrastructure amounting to\n₱ 227,262,250",
+    "references": "[https://earthquake.phivolcs.dost.gov.ph/2022_Earthquake_Information/October/2022_1025_1459_B5F.html, https://monitoring-dashboard.ndrrmc.gov.ph/page/situation/situational-report-for-magnitude-64-earthquake-in-lagayan-abra-2022]"
+  },
+  {
+    "title": "M6.4 Earthquake 388 km S 49° E of Sarangani Island (Municipality Of Sarangani) (Davao Occidental)",
+    "magnitude": 6.4,
+    "location": "388 km S 49° E of Sarangani Island (Municipality Of Sarangani) (Davao Occidental)",
+    "latitude": 3.18,
+    "longitude": 128.13,
+    "depth": 130,
+    "eventTime": "02-24-2023T04:02:47.000+00:00",
+    "instrumentRecordings": "[R1EFC,R3B2D,RBD68,RF8C0]",
+    "eventSummary": "A magnitude-6.4 earthquake struck Southern Mindanao at 4:02 a.m., with the epicenter located 388 kilometers south of Sarangani town in Davao Occidental. The quake was felt at Intensity II in Palimbang, Sultan Kudarat, and Gian, Sarangani province, and Intensity I in Kiamba, Sarangani, with no expected damage or aftershocks.",
+    "references": "[https://earthquake.phivolcs.dost.gov.ph/2023_Earthquake_Information/February/2023_0223_2002_B3F.html, https://www.philstar.com/nation/2023/02/25/2247412/magnitude-64-quake-jolts-southern-mindanao]"
+  }
+]


### PR DESCRIPTION
# Detailed Description

### Summary
<!--- Please link the related issue/task --> 
> In this PR, the ff endpoints are added:
1.  [/significant-eqs](https://gold-eclipse-264677.postman.co/workspace/Team-Workspace~8cd9ea6e-2f96-4fe1-8ad2-996d5db8ca80/request/27239821-879e0afc-9743-445c-9431-1f3390a257fd?action=share&creator=26343673&ctx=documentation)
2. [/significant-eqs/all](https://gold-eclipse-264677.postman.co/workspace/Team-Workspace~8cd9ea6e-2f96-4fe1-8ad2-996d5db8ca80/request/27239821-632cf4da-75f4-43d2-9a37-33f5482cfd83?action=share&creator=26343673&ctx=documentation)

<!--- Please include a detailed summary of the changes --> 
 
### Motivation & Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
### Dependencies
<!--- List any dependencies that are required for this change. -->

### Type of change
<!--- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!--- If breaking change, detail which existing functionality/s should or is expected to change -->


# How Has This Been Tested?
<!--- Remove this section if not applicable -->

<!--- Please describe the tests that you ran to verify your changes. -->
<!--- Provide instructions so we can reproduce. -->
<!--- Please also list any relevant details for your test configuration -->

A. [/significant-eqs](https://gold-eclipse-264677.postman.co/workspace/Team-Workspace~8cd9ea6e-2f96-4fe1-8ad2-996d5db8ca80/request/27239821-879e0afc-9743-445c-9431-1f3390a257fd?action=share&creator=26343673&ctx=documentation) - POST endpoint for getting information from a specific event
  - pass object_id of one entry of significant eq saved in database:
  ```json
  { "id": "66f0dcd0ebb39af574260fbe" }
  ```
  - this will output the earthquake information (title, magnitude, longitude, latitude, depth, eventTime, instrumentRecordings, eventSummary, and article references), as shown in the example below:
  ```json
  {
    "status": 0,
    "message": "Earthquake Information found",
    "payload": {
        "_id": "66f0dcd0ebb39af574260fbe",
        "title": "M7.4 Earthquake 029 km N 74° E of Hinatuan (Surigao Del Sur)",
        "magnitude": 7.4,
        "longitude": 126.59,
        "latitude": 8.44,
        "depth": 26,
        "location": "029 km N 74° E of Hinatuan (Surigao Del Sur)",
        "eventTime": "2023-12-02T22:37:05.000Z",
        "instrumentRecordings": [
            "R1382",
            "R8095",
            "RBD68"
        ],
        "eventSummary": "<p>A magnitude 7.4 earthquake struck Surigao del Sur on December 2, resulting in three deaths, 48 injuries, 9,765 affected families and nearly 3,000 aftershocks ranging from magnitude 1.4 to 6.6. Significant damage includes destroyed homes, a fire in a Butuan City hospital and disrupted infrastructure estimated to be valued at around P45 million.</p>",
        "references": [
            "https://earthquake.phivolcs.dost.gov.ph/2023_Earthquake_Information/December/2023_1202_1437_B3F.html",
            "https://newsinfo.inquirer.net/1869567/live-updates-magnitude-7-4-surigao-del-sur-earthquake",
            "https://www.rappler.com/philippines/mindanao/surigao-del-sur-earthquake-december-2-2023/"
        ]
     }
  }
  ```

B. [/significant-eqs/all](https://gold-eclipse-264677.postman.co/workspace/Team-Workspace~8cd9ea6e-2f96-4fe1-8ad2-996d5db8ca80/request/27239821-632cf4da-75f4-43d2-9a37-33f5482cfd83?action=share&creator=26343673&ctx=documentation) - GET endpoint for getting a list of all significant eqs saved in db (significant-eqs collection)
  - perform a GET request on /significant-eqs/all endpoint
  - this will output a list of significant earthquakes, together with eq-info of each event, in json format.


# Checklist:
<!--- Double check the following and leave uncheck those that you haven't done or are not applicable. -->

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
